### PR TITLE
Variadic parameters cannot use a nullable type sign

### DIFF
--- a/src/ReflectionTools.php
+++ b/src/ReflectionTools.php
@@ -353,7 +353,7 @@ class ReflectionTools
                 $result .= ', ';
             }
 
-            if ($parameter->allowsNull() && ! $parameter->isDefaultValueAvailable()) {
+            if ($parameter->allowsNull() && ! $parameter->isDefaultValueAvailable() && ! $parameter->isVariadic()) {
                 $result .= '?';
             }
 


### PR DESCRIPTION
In case of a a variadic parameter, a '?' was being used before the ellipsis, generating the error:

<i><b>Parse error:</b> syntax error, unexpected '...' (T_ELLIPSIS) in <b>[file...]</b></i>

<b>Example:</b>
```php
namespace ericklima_comp\Reflection {

	function f1(int $p1, ...$p2) {
		echo 'OK!';
	}

	$function_code = (new \Brick\Reflection\ReflectionTools())->exportFunction( new \ReflectionFunction('ericklima_comp\\Reflection\\f1') );
	$function_code .= '{ echo " NOT OK!"; }';
	
	echo $function_code;
	
	eval($function_code);
	
	exit;
}
```